### PR TITLE
fix issue #71

### DIFF
--- a/core/src/main/scala/raw/calculus/SyntaxAnalyzer.scala
+++ b/core/src/main/scala/raw/calculus/SyntaxAnalyzer.scala
@@ -38,22 +38,22 @@ object SyntaxAnalyzer extends PositionedParserUtilities {
 
   lazy val monoidMerge: PackratParser[Monoid] =
     positioned(
-      "union" ^^^ SetMonoid() |
-      "bag_union" ^^^ BagMonoid() |
-      "append" ^^^ ListMonoid() |
-      "max" ^^^ MaxMonoid())
+      kw("union") ^^^ SetMonoid() |
+      kw("bag_union") ^^^ BagMonoid() |
+      kw("append") ^^^ ListMonoid() |
+      kw("max") ^^^ MaxMonoid())
 
   lazy val orExp: PackratParser[Exp] =
     positioned(andExp * (or ^^ { case op => { (e1: Exp, e2: Exp) => MergeMonoid(op, e1, e2) } }))
 
   lazy val or: PackratParser[OrMonoid] =
-    positioned("or" ^^^ OrMonoid())
+    positioned(kw("or") ^^^ OrMonoid())
 
   lazy val andExp: PackratParser[Exp] =
     positioned(comparisonExp * (and ^^ { case op => { (e1: Exp, e2: Exp) => MergeMonoid(op, e1, e2) } }))
 
   lazy val and: PackratParser[AndMonoid] =
-    positioned("and" ^^^ AndMonoid())
+    positioned(kw("and") ^^^ AndMonoid())
 
   lazy val comparisonExp: PackratParser[Exp] =
     positioned(termExp ~ comparisonOp ~ termExp ^^ { case e1 ~ op ~ e2 => BinaryExp(op, e1, e2) }) |
@@ -70,7 +70,7 @@ object SyntaxAnalyzer extends PositionedParserUtilities {
       ">" ^^^ Gt())
 
   lazy val not: PackratParser[Not] =
-    positioned("not" ^^^ Not())
+    positioned(kw("not") ^^^ Not())
 
   lazy val termExp: PackratParser[Exp] =
     positioned(productExp * (
@@ -126,8 +126,8 @@ object SyntaxAnalyzer extends PositionedParserUtilities {
     positioned("null" ^^^ Null())
 
   lazy val boolConst: PackratParser[BoolConst] =
-    positioned("true" ^^^ BoolConst(true)) |
-    positioned("false" ^^^ BoolConst(false))
+    positioned(kw("true") ^^^ BoolConst(true)) |
+    positioned(kw("false") ^^^ BoolConst(false))
 
   lazy val stringConst: PackratParser[StringConst] =
     positioned(stringLit ^^ StringConst)
@@ -166,7 +166,7 @@ object SyntaxAnalyzer extends PositionedParserUtilities {
     })
 
   lazy val ifThenElse: PackratParser[IfThenElse] =
-    positioned("if" ~> exp ~ ("then" ~> exp) ~ ("else" ~> exp) ^^ IfThenElse)
+    positioned(kw("if") ~> exp ~ (kw("then") ~> exp) ~ (kw("else") ~> exp) ^^ IfThenElse)
 
   lazy val recordConsIdns: PackratParser[RecordCons] =
     positioned("(" ~> rep1sep((attrName <~ ":=") ~ exp, ",") <~ ")" ^^ {
@@ -188,17 +188,17 @@ object SyntaxAnalyzer extends PositionedParserUtilities {
 
   lazy val primitiveMonoid: PackratParser[PrimitiveMonoid] =
     positioned(
-      "sum" ^^^ SumMonoid() |
-      "multiply" ^^^ MultiplyMonoid() |
-      "max" ^^^ MaxMonoid() |
-      "or" ^^^ OrMonoid() |
-      "and" ^^^ AndMonoid())
+      kw("sum") ^^^ SumMonoid() |
+      kw("multiply") ^^^ MultiplyMonoid() |
+      kw("max") ^^^ MaxMonoid() |
+      kw("or") ^^^ OrMonoid() |
+      kw("and") ^^^ AndMonoid())
 
   lazy val collectionMonoid: PackratParser[CollectionMonoid] =
     positioned(
-      "set" ^^^ SetMonoid() |
-      "bag" ^^^ BagMonoid() |
-      "list" ^^^ ListMonoid())
+      kw("set") ^^^ SetMonoid() |
+      kw("bag") ^^^ BagMonoid() |
+      kw("list") ^^^ ListMonoid())
 
   lazy val qualifier: PackratParser[Qual] =
     gen |
@@ -312,5 +312,8 @@ object SyntaxAnalyzer extends PositionedParserUtilities {
 
   lazy val idnUse: PackratParser[IdnUse] =
     positioned(ident ^^ IdnUse)
+
+  def kw (s : String) =
+    (s + "\\b").r
 
 }

--- a/core/src/test/scala/raw/calculus/SyntaxAnalyzerTest.scala
+++ b/core/src/test/scala/raw/calculus/SyntaxAnalyzerTest.scala
@@ -15,6 +15,16 @@ class SyntaxAnalyzerTest extends FunTest {
     assert(actual == expected.getOrElse(q))
   }
 
+  def parseError(q: String, expected: Option[String] = None): Unit = {
+    assert(SyntaxAnalyzer(q).isLeft)
+    if (expected.isDefined)
+      SyntaxAnalyzer(q) match {
+        case Left(err) => assert(err.contains(expected.get))
+      }
+  }
+
+  def parseError(q: String, expected: String): Unit = parseError(q, Some(expected))
+
   test("cern events") {
     matches("for (e1 <- Events; e1.RunNumber > 100) yield set (muon := e1.muon)")
   }
@@ -167,5 +177,30 @@ class SyntaxAnalyzerTest extends FunTest {
 
   test("parentheses - lt and comparison - variables - redundant") {
     matches("(a < b) = c", "a < b = c")
+  }
+}
+
+  test("#71 (keywords issue)") {
+    matches("""{ v := nothing; v }""")
+    matches("""{ v := nottrue; v }""")
+    parseError("""for (v <- collection) yield unionv""", "illegal monoid")
+    parseError("""for (v <- collection) yield bag_unionv""", "illegal monoid")
+    parseError("""for (v <- collection) yield appendv""", "illegal monoid")
+    parseError("""for (v <- collection) yield setv""", "illegal monoid")
+    parseError("""for (v <- collection) yield listv""", "illegal monoid")
+    parseError("""for (v <- collection) yield bagv""", "illegal monoid")
+    parseError("""for (v <- booleans) yield andv""", "illegal monoid")
+    parseError("""for (v <- booleans) yield andfalse""", "illegal monoid")
+    parseError("""for (v <- booleans) yield orv""", "illegal monoid")
+    parseError("""for (v <- booleans) yield ortrue""", "illegal monoid")
+    parseError("""for (v <- numbers) yield maxv""", "illegal monoid")
+    parseError("""for (v <- numbers) yield max12""", "illegal monoid")
+    parseError("""for (v <- numbers) yield sumv""", "illegal monoid")
+    parseError("""for (v <- numbers) yield sum123""", "illegal monoid")
+    parseError("""for (v <- numbers) yield multiplyv""", "illegal monoid")
+    parseError("""for (v <- numbers) yield multiply123""", "illegal monoid")
+    matches("""for (r <- records; v := trueandfalse) yield set v""")
+    matches("""for (r <- records; v := falseortrue) yield set v""")
+    matches("""{ v := iftruethen1else2; v }""")
   }
 }


### PR DESCRIPTION
keywords recognized in the middle of identifiers (nothing => not hing).

Also added a number of test cases which all fail without the change.

Not all keywords were flagged in the parser because I wasn't able to trigger a bug for all of them. For example "for", etc.